### PR TITLE
simple robot container test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,7 @@ spotless {
             include '**/*.java'
             exclude '**/build/**', '**/build-*/**'
             exclude '**/BuildConstants.java'
+            exclude 'src/test/**/*.java'
         }
         toggleOffOn()
         googleJavaFormat()

--- a/src/test/java/RobotContainerTest.java
+++ b/src/test/java/RobotContainerTest.java
@@ -1,0 +1,23 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import edu.wpi.first.hal.HAL;
+import frc.robot.RobotContainer;
+
+public class RobotContainerTest {
+
+    RobotContainer frcRobot;
+
+    @BeforeEach
+    public void setup() {
+        HAL.initialize(500, 0);
+    }
+
+    @Test
+    public void test() {
+        frcRobot = new RobotContainer();
+        assertEquals(1, 1);
+    }
+}


### PR DESCRIPTION
This PR creates one test that is skippable (via -x test) so that we can avoid RobotContainer null errors. 
Adding tests does force gradle to run them before deploying/building.